### PR TITLE
Fix URL change detection to cover SPA navigations

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -4,9 +4,6 @@
 // Description: A browser extension to modify GitHub contribution graphs to start weeks on Monday.
 
 function startWeekOnMonday(table) {
-    // Prevent repeated modification
-    if (table.dataset.weekMondayCorrected) return;
-
     // Get the tbody and check for 7 rows (one per day)
     const tbody = table.querySelector('tbody');
     if (!tbody) {
@@ -58,8 +55,6 @@ function startWeekOnMonday(table) {
             span.setAttribute('style', newStyle);
         }
 
-        // 4. Mark as corrected
-        table.dataset.weekMondayCorrected = 'true';
     } catch (err) {
         console.error('[Contribution Graph Realignment] Failed during DOM manipulation:', err);
     }
@@ -77,7 +72,9 @@ function startObserver() {
     // The observer is created once and kept alive — disconnecting it prematurely
     // breaks realignment when navigating from a non-profile page to a profile page.
     const observer = new MutationObserver(tryCorrect);
-    observer.observe(document.body, { childList: true, subtree: true });
+    // Observe documentElement, not body — Turbo replaces the entire <body> element on
+    // navigation, which would leave an observer on document.body watching a detached node.
+    observer.observe(document.documentElement, { childList: true, subtree: true });
 }
 
 // Main entry point
@@ -96,7 +93,6 @@ function main() {
             // boundary, so this fires reliably for in-page link clicks without needing to
             // patch history.pushState (which would only affect the content script's own world).
             document.addEventListener('turbo:load', tryCorrect);
-            window.addEventListener('popstate', tryCorrect);
         }
     });
 }

--- a/extension/content.js
+++ b/extension/content.js
@@ -96,6 +96,7 @@ function main() {
             // boundary, so this fires reliably for in-page link clicks without needing to
             // patch history.pushState (which would only affect the content script's own world).
             document.addEventListener('turbo:load', tryCorrect);
+            window.addEventListener('popstate', tryCorrect);
         }
     });
 }

--- a/extension/content.js
+++ b/extension/content.js
@@ -98,15 +98,16 @@ function observeTable() {
 
 // Safe URL change detection
 function onUrlChange(callback) {
-    let lastUrl = location.href;
-    const checkUrl = () => {
-        if (location.href !== lastUrl) {
-            lastUrl = location.href;
+    // Wrap history methods so SPA navigations (pushState/replaceState) also trigger the callback.
+    // popstate only fires for back/forward; GitHub uses pushState for in-page link clicks.
+    for (const method of ['pushState', 'replaceState']) {
+        const original = history[method];
+        history[method] = function (...args) {
+            original.apply(this, args);
             callback();
-        }
-    };
-    window.addEventListener('popstate', checkUrl);
-    setInterval(checkUrl, 500);
+        };
+    }
+    window.addEventListener('popstate', callback);
 }
 
 // Main entry point

--- a/extension/content.js
+++ b/extension/content.js
@@ -67,47 +67,17 @@ function startWeekOnMonday(table) {
 
 // --- Initialization and MutationObserver Logic ---
 
-function observeTable() {
-    // Try to correct immediately
+function tryCorrect() {
     const table = document.querySelector('.ContributionCalendar-grid');
-    if (table) {
-        startWeekOnMonday(table);
-    }
-
-    // Observe for future changes
-    const observer = new MutationObserver(() => {
-        const table = document.querySelector('.ContributionCalendar-grid');
-        if (table) {
-            startWeekOnMonday(table);
-        }
-    });
-
-    // Start observing the body for changes
-    observer.observe(document.body, {
-        childList: true,
-        subtree: true,
-    });
-
-    // Disconnect observer if .js-yearly-contributions is not present after 5 seconds
-    setTimeout(() => {
-        if (!document.querySelector('.js-yearly-contributions')) {
-            observer.disconnect();
-        }
-    }, 5000);
+    if (table) startWeekOnMonday(table);
 }
 
-// Safe URL change detection
-function onUrlChange(callback) {
-    // Wrap history methods so SPA navigations (pushState/replaceState) also trigger the callback.
-    // popstate only fires for back/forward; GitHub uses pushState for in-page link clicks.
-    for (const method of ['pushState', 'replaceState']) {
-        const original = history[method];
-        history[method] = function (...args) {
-            original.apply(this, args);
-            callback();
-        };
-    }
-    window.addEventListener('popstate', callback);
+function startObserver() {
+    // Watch for the contribution graph being added/replaced anywhere in the page.
+    // The observer is created once and kept alive — disconnecting it prematurely
+    // breaks realignment when navigating from a non-profile page to a profile page.
+    const observer = new MutationObserver(tryCorrect);
+    observer.observe(document.body, { childList: true, subtree: true });
 }
 
 // Main entry point
@@ -120,10 +90,12 @@ function main() {
     // Check if realignment is enabled before running
     storage.sync.get({ enableRealignment: true }, (items) => {
         if (items.enableRealignment) {
-            observeTable();
-            onUrlChange(() => {
-                observeTable();
-            });
+            tryCorrect();
+            startObserver();
+            // GitHub uses Turbo for SPA navigation. DOM events cross the MV3 isolated world
+            // boundary, so this fires reliably for in-page link clicks without needing to
+            // patch history.pushState (which would only affect the content script's own world).
+            document.addEventListener('turbo:load', tryCorrect);
         }
     });
 }

--- a/tests/verify.js
+++ b/tests/verify.js
@@ -182,10 +182,15 @@ if (rows[6].cells.length !== 2) {
 }
 console.log('SUCCESS: Extra cell deleted from shifted row.');
 
-// 4. Check Correction Marker
-if (table.dataset.weekMondayCorrected !== 'true') {
-    throw new Error('Verification Failed: Dataset marker not set.');
+// 4. Check idempotency — calling again must be a no-op (guard relies on span text, not a dataset flag)
+startWeekOnMonday(table);
+rows = tbody.rows;
+if (rows[0].cells[0].querySelector('span[aria-hidden="true"]').textContent !== 'Mon') {
+    throw new Error('Idempotency Failed: Second call changed row order.');
 }
-console.log('SUCCESS: Correction marker set.');
+if (rows[6].cells[0].querySelector('span[aria-hidden="true"]').textContent !== 'Sun') {
+    throw new Error('Idempotency Failed: Second call moved Sun row again.');
+}
+console.log('SUCCESS: Second call is a no-op (idempotent).');
 
 console.log('All checks passed.');


### PR DESCRIPTION
## Summary

- Replace `setInterval`-based URL polling with a `turbo:load` event listener, which works reliably across MV3's isolated world boundary and fires for all Turbo-driven navigations
- Change the `MutationObserver` target from `document.body` to `document.documentElement` — Turbo replaces the entire `<body>` on navigation, leaving any `body`-attached observer watching a detached dead node
- Remove the 5-second observer disconnect, which silently broke realignment when navigating to a profile page after spending time elsewhere
- Remove the `dataset.weekMondayCorrected` flag, which prevented re-correction after GitHub's in-place DOM updates (e.g., clicking a year filter)

## Root causes fixed

The original polling detected URL changes but not the timing of DOM updates. The `document.body` observer became dead after any Turbo navigation (Turbo swaps `<body>` wholesale), meaning GitHub's own post-render graph updates went undetected and the graph reverted to Sun-first. The `dataset` flag then prevented recovery even when the observer did catch a change.

## Test plan

- [x] Load a GitHub profile page — graph should be Monday-first
- [x] Click a year filter (e.g., 2024) — graph should stay Monday-first
- [x] Navigate away (e.g., to Repositories) and back to Overview — graph should be Monday-first
- [x] Use browser back/forward across multiple pages — navigation should work and graph should be Monday-first where applicable
- [x] Disable the extension, navigate to a profile, re-enable — no change until page reload (expected)
