### PR TITLE
Clarify why deleteCell(1) is used when shifting the Sunday row

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -42,9 +42,13 @@ function startWeekOnMonday(table) {
         const sundayRow = tbody.rows[0];
         tbody.appendChild(sundayRow);
 
-        // All checks on lastRow.cells are redundant; we validated cell count before moving the row.
-
         // 2. Shift Sunday row's contribution data
+        // By moving the Sunday row from the top to the bottom, the Sundays in each 
+        // column become "backward" (they represent the date *before* the Monday above them).
+        // We delete the first cell (index 1, as index 0 is the label) so that 
+        // all subsequent Sundays shift left by one column.
+        // This ensures that the Sunday at the bottom of a column is the one 
+        // that *follows* the Monday at the top of that same column.
         const lastRow = tbody.rows[tbody.rows.length - 1];
         lastRow.deleteCell(1);
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -43,11 +43,11 @@ function startWeekOnMonday(table) {
         tbody.appendChild(sundayRow);
 
         // 2. Shift Sunday row's contribution data
-        // By moving the Sunday row from the top to the bottom, the Sundays in each 
+        // By moving the Sunday row from the top to the bottom, the Sundays in each
         // column become "backward" (they represent the date *before* the Monday above them).
-        // We delete the first cell (index 1, as index 0 is the label) so that 
+        // We delete the first cell (index 1, as index 0 is the label) so that
         // all subsequent Sundays shift left by one column.
-        // This ensures that the Sunday at the bottom of a column is the one 
+        // This ensures that the Sunday at the bottom of a column is the one
         // that *follows* the Monday at the top of that same column.
         const lastRow = tbody.rows[tbody.rows.length - 1];
         lastRow.deleteCell(1);


### PR DESCRIPTION
Improve and expand the inline comment explaining why the Sunday row is moved to the bottom and why deleteCell(1) is used. The new comment clarifies that index 0 is a label, deleting cell 1 shifts Sundays left so the Sunday at the bottom follows the Monday above it, and replaces an earlier redundant remark about validated cell counts.