### PR TITLE
Automate releases based on manifest version

### DIFF
--- a/.github/workflows/extension-package-builder.yml
+++ b/.github/workflows/extension-package-builder.yml
@@ -27,7 +27,7 @@ jobs:
 
       # 2. Create the GitHub release and attach the ZIP file
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.ZIP_NAME }}
           name: Browser Extension ${{ github.ref_name }}

--- a/.github/workflows/extension-package-builder.yml
+++ b/.github/workflows/extension-package-builder.yml
@@ -1,36 +1,65 @@
 name: Extension Package Builder
 
+# Runs on every push to main. Only creates a release if the version in
+# extension/manifest.json has been bumped to a value that doesn't already
+# have a matching git tag. To release a new version, just update "version"
+# in manifest.json, commit, and push — this workflow handles the rest.
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
+    # Needed so the workflow can create tags and GitHub Releases
     permissions:
       contents: write
-
-    env:
-      ZIP_NAME: contribution-graph-realignment-tool-${{ github.ref_name }}.zip
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Fetch the full git history so we can see all existing tags below
+          fetch-depth: 0
 
-      # 1. Package the extension as standard ZIP file
+      # Read the "version" field from the extension manifest and store it
+      # so later steps can reference it as ${{ steps.version.outputs.value }}
+      - name: Read version from manifest
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' extension/manifest.json)
+          echo "value=$VERSION" >> $GITHUB_OUTPUT
+
+      # Check whether a tag like "v1.2.0" already exists for this version.
+      # If it does, the version hasn't changed and we skip the release steps.
+      - name: Check if tag already exists
+        id: tag_check
+        run: |
+          if git tag | grep -qx "v${{ steps.version.outputs.value }}"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Zip the entire extension/ folder — this is the file uploaded to the
+      # Chrome Web Store / Firefox Add-ons. Only runs if the tag is new.
       - name: Create Extension Package
+        if: steps.tag_check.outputs.exists == 'false'
         run: |
           cd extension
-          zip -r ../$ZIP_NAME .
+          zip -r ../contribution-graph-realignment-tool-v${{ steps.version.outputs.value }}.zip .
 
-      # 2. Create the GitHub release and attach the ZIP file
+      # Create the GitHub Release, attach the ZIP, and create the git tag.
+      # The GITHUB_TOKEN is provided automatically by GitHub Actions — no setup needed.
       - name: Create GitHub Release
+        if: steps.tag_check.outputs.exists == 'false'
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.ZIP_NAME }}
-          name: Browser Extension ${{ github.ref_name }}
+          tag_name: v${{ steps.version.outputs.value }}
+          files: contribution-graph-realignment-tool-v${{ steps.version.outputs.value }}.zip
+          name: Browser Extension v${{ steps.version.outputs.value }}
           draft: false
           prerelease: false
         env:

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Contribution Graph Realignment Tool",
-    "version": "1.1",
+    "version": "0.3",
     "description": "A browser extension by The GitHub Temporal Correction Initiative. Dedicated to restoring chronological integrity to GitHub's contribution graph. Because Monday comes first!",
     "content_scripts": [
         {


### PR DESCRIPTION
## Summary
- Workflow now triggers on push to `main` instead of manual git tags
- Reads the version from `extension/manifest.json` and checks if a matching tag already exists — only creates a release if the version is new
- Bumps `softprops/action-gh-release` from v1 to v2
- Aligns manifest version with latest published release (v0.2 → v0.3)

## How to release going forward
Bump the `version` field in `extension/manifest.json`, commit, and push to `main`. The workflow handles tagging and publishing automatically.
