### PR TITLE
Upgrade actions to Node.js 24 runtime

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - ci

--- a/.github/workflows/extension-package-builder.yml
+++ b/.github/workflows/extension-package-builder.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch the full git history so we can see all existing tags below
           fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
       # The GITHUB_TOKEN is provided automatically by GitHub Actions — no setup needed.
       - name: Create GitHub Release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.value }}
           files: contribution-graph-realignment-tool-v${{ steps.version.outputs.value }}.zip

--- a/.github/workflows/extension-package-builder.yml
+++ b/.github/workflows/extension-package-builder.yml
@@ -60,6 +60,7 @@ jobs:
           tag_name: v${{ steps.version.outputs.value }}
           files: contribution-graph-realignment-tool-v${{ steps.version.outputs.value }}.zip
           name: Browser Extension v${{ steps.version.outputs.value }}
+          generate_release_notes: true
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from v4 to v6
- Bumps `softprops/action-gh-release` from v2 to v3
- Adds auto-generated release notes listing all PRs merged since the previous release
- Adds `.github/release.yml` to exclude PRs labelled `ci` from release notes

Both action upgrades are runtime-only — no input or configuration changes needed.

## Why
GitHub is deprecating Node.js 20 on Actions runners. Forced migration
is June 2nd, 2026, with Node.js 20 fully removed on September 16th, 2026.
