### PR TITLE
Declare minimum_chrome_version in manifest

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -29,7 +29,8 @@
     },
     "browser_specific_settings": {
         "gecko": {
-            "id": "{8c2d1b7e-e5e3-4b68-8097-f58c7344933a}"
+            "id": "{8c2d1b7e-e5e3-4b68-8097-f58c7344933a}",
+            "strict_min_version": "109.0"
         }
     }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,6 +19,7 @@
         "48": "icons/icon48.png",
         "128": "icons/icon128.png"
     },
+    "minimum_chrome_version": "88",
     "permissions": [
         "storage"
     ],


### PR DESCRIPTION
Closes #44

## Summary
- Adds `"minimum_chrome_version": "88"` - first Chrome version with Manifest V3 support
- Adds `"strict_min_version": "109.0"` to `browser_specific_settings.gecko` - first Firefox version with Manifest V3 support

## Test plan
- [x] Load unpacked extension in Chrome - no errors in extension management page
- [x] Load unpacked extension in Firefox - no errors in extension management page