### PR TITLE
Exclude release archives from git and add .gitignore comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# Claude Code project settings and memory
 .claude/
+
+# Release archives produced locally for store submission
+*.zip


### PR DESCRIPTION
## Summary

- Adds `*.zip` to `.gitignore` so locally built release archives are never accidentally committed
- Adds inline comments to `.gitignore` explaining each exclusion

## Test plan

- [x] Confirm `extension-v*.zip` files no longer appear as untracked in `git status`
- [x] Confirm `.gitignore` comments accurately describe each rule