### PR TITLE
Fix TypeError in getLabelSpan when row has no cells

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -81,7 +81,7 @@ function getSundayRow(tbody) {
 }
 
 function getLabelSpan(row) {
-    return row.cells[0].querySelector('span[aria-hidden="true"]');
+    return row.cells[0]?.querySelector('span[aria-hidden="true"]') ?? null;
 }
 // #endregion
 


### PR DESCRIPTION
Closes #35

## Summary

- Added optional chaining on `row.cells[0]` in `getLabelSpan` so rows with no `<td>` children return `null` instead of throwing a `TypeError`
- All three callers already handle `null` correctly, so no other changes are needed

## Test plan

- [x] Load the extension on a GitHub profile page — contribution graph realigns as expected
- [x] Verify no console errors on profiles with a normally-rendered graph