### PR TITLE
Consolidate Sunday validation and simplify entry point

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -38,8 +38,6 @@ function validateGraph(tbody) {
     }
 
     const firstRow = tbody.rows[0];
-
-    // Guard before calling getLabelSpan — needs at least a label cell and one data cell
     if (firstRow.cells.length < 2) {
         console.error('[Contribution Graph Realignment] Failed: Sunday row does not have enough cells to shift contribution data.');
         return false;

--- a/extension/content.js
+++ b/extension/content.js
@@ -28,20 +28,16 @@ function validateGraph(tbody) {
     }
 
     const firstRow = tbody.rows[0];
+    const span = getDayLabel(firstRow);
+
+    // Silent return — row 0 not being Sunday means the graph is already corrected.
+    // This fires on every subsequent mutation after realignment, so logging here would spam the console.
+    if (!span || span.textContent.trim() !== 'Sun') return false;
+
     if (firstRow.cells.length < 2) {
         console.error('[Contribution Graph Realignment] Failed: Sunday row does not have enough cells to shift contribution data.');
         return false;
     }
-
-    const span = getDayLabel(firstRow);
-    if (!span) {
-        console.error('[Contribution Graph Realignment] Failed: No label span found in first row.');
-        return false;
-    }
-
-    // Silent return — row 0 not being Sunday means the graph is already corrected.
-    // This fires on every subsequent mutation after realignment, so logging here would spam the console.
-    if (span.textContent.trim() !== 'Sun') return false;
 
     return true;
 }

--- a/extension/content.js
+++ b/extension/content.js
@@ -39,10 +39,9 @@ function validateGraph(tbody) {
         return false;
     }
 
-    if (span.textContent.trim() !== 'Sun') {
-        console.error('[Contribution Graph Realignment] Failed: First row is not labeled "Sun". Found:', span.textContent.trim());
-        return false;
-    }
+    // Silent return — row 0 not being Sunday means the graph is already corrected.
+    // This fires on every subsequent mutation after realignment, so logging here would spam the console.
+    if (span.textContent.trim() !== 'Sun') return false;
 
     return true;
 }

--- a/extension/content.js
+++ b/extension/content.js
@@ -6,13 +6,13 @@
 // --- Contribution Graph Realignment ---------------------------------------------------------------------------------
 // #region
 
-function startWeekOnMonday(table) {
     const tbody = table.querySelector('tbody');
     if (!tbody) {
         console.error('[Contribution Graph Realignment] Failed: No <tbody> found in contribution graph table.');
         return;
     }
 
+function applyCorrection() {
     if (!validateGraph(tbody)) return;
 
     const sundayRow = getSundayRow(tbody);
@@ -86,16 +86,11 @@ function getDayLabel(row) {
 // --- Initialization and MutationObserver Logic ----------------------------------------------------------------------
 // #region
 
-function tryCorrect() {
-    const table = document.querySelector('.ContributionCalendar-grid');
-    if (table) startWeekOnMonday(table);
-}
-
 function startObserver() {
     // Watch for the contribution graph being added/replaced anywhere in the page.
     // The observer is created once and kept alive — disconnecting it prematurely
     // breaks realignment when navigating from a non-profile page to a profile page.
-    const observer = new MutationObserver(tryCorrect);
+    const observer = new MutationObserver(applyCorrection);
 
     // Observe documentElement, not body — Turbo replaces the entire <body> element on
     // navigation, which would leave an observer on document.body watching a detached node.
@@ -113,12 +108,12 @@ const storage = typeof browser !== 'undefined' && browser.storage ? browser.stor
 function main() {
     storage.sync.get({ enableRealignment: true }, (items) => {
         if (items.enableRealignment) {
-            tryCorrect();
+            applyCorrection();
             startObserver();
             // GitHub uses Turbo for SPA navigation. DOM events cross the MV3 isolated world
             // boundary, so this fires reliably for in-page link clicks without needing to
             // patch history.pushState (which would only affect the content script's own world).
-            document.addEventListener('turbo:load', tryCorrect);
+            document.addEventListener('turbo:load', applyCorrection);
         }
     });
 }

--- a/extension/content.js
+++ b/extension/content.js
@@ -65,7 +65,7 @@ function realignGraph(tbody, sundayRow) {
     sundayRow.deleteCell(1);
 
     // 3. Fix the visibility of the "Sun" label.
-    const span = getLabelSpan(sundayRow);
+    const span = getDayLabel(sundayRow);
     if (span && span.hasAttribute('style')) {
         const newStyle = span.getAttribute('style').replace('Circle(0)', 'None');
         span.setAttribute('style', newStyle);
@@ -80,7 +80,7 @@ function getSundayRow(tbody) {
     return null;
 }
 
-function getLabelSpan(row) {
+function getDayLabel(row) {
     return row.cells[0]?.querySelector('span[aria-hidden="true"]') ?? null;
 }
 // #endregion

--- a/extension/content.js
+++ b/extension/content.js
@@ -18,10 +18,9 @@ function applyCorrection() {
 }
 
 function validateGraph(tbody) {
-    if (!tbody) {
-        console.error('[Contribution Graph Realignment] Failed: Contribution graph tbody not found.');
-        return false;
-    }
+    // No error logged — the MutationObserver fires on every DOM change across all pages,
+    // so the contribution graph being absent is the normal case, not a failure.
+    if (!tbody) return false;
 
     if (tbody.rows.length !== 7) {
         console.error('[Contribution Graph Realignment] Failed: Contribution graph does not have 7 rows. Found:', tbody.rows.length);

--- a/extension/content.js
+++ b/extension/content.js
@@ -6,32 +6,23 @@
 // --- Contribution Graph Realignment ---------------------------------------------------------------------------------
 // #region
 
-    const tbody = table.querySelector('tbody');
-    if (!tbody) {
-        console.error('[Contribution Graph Realignment] Failed: No <tbody> found in contribution graph table.');
-        return;
-    }
-
 function applyCorrection() {
+    const tbody = document.querySelector('.ContributionCalendar-grid tbody');
     if (!validateGraph(tbody)) return;
 
-    const sundayRow = getSundayRow(tbody);
-    if (!sundayRow) {
-        console.error('[Contribution Graph Realignment] Failed: No Sunday row found in contribution graph.');
-        return;
-    }
-
-    // Already corrected — Sunday has been moved to the bottom
-    if (tbody.rows[0] !== sundayRow) return;
-
     try {
-        realignGraph(tbody, sundayRow);
+        realignGraph(tbody, tbody.rows[0]);
     } catch (err) {
         console.error('[Contribution Graph Realignment] Failed during DOM manipulation:', err);
     }
 }
 
 function validateGraph(tbody) {
+    if (!tbody) {
+        console.error('[Contribution Graph Realignment] Failed: Contribution graph tbody not found.');
+        return false;
+    }
+
     if (tbody.rows.length !== 7) {
         console.error('[Contribution Graph Realignment] Failed: Contribution graph does not have 7 rows. Found:', tbody.rows.length);
         return false;
@@ -43,8 +34,14 @@ function validateGraph(tbody) {
         return false;
     }
 
-    if (!getLabelSpan(firstRow)) {
+    const span = getDayLabel(firstRow);
+    if (!span) {
         console.error('[Contribution Graph Realignment] Failed: No label span found in first row.');
+        return false;
+    }
+
+    if (span.textContent.trim() !== 'Sun') {
+        console.error('[Contribution Graph Realignment] Failed: First row is not labeled "Sun". Found:', span.textContent.trim());
         return false;
     }
 
@@ -68,14 +65,6 @@ function realignGraph(tbody, sundayRow) {
         const newStyle = span.getAttribute('style').replace('Circle(0)', 'None');
         span.setAttribute('style', newStyle);
     }
-}
-
-function getSundayRow(tbody) {
-    for (const row of tbody.rows) {
-        const span = getLabelSpan(row);
-        if (span && span.textContent.trim() === 'Sun') return row;
-    }
-    return null;
 }
 
 function getDayLabel(row) {


### PR DESCRIPTION
Closes #45

## Summary

- `validateGraph` now owns all precondition checks, including tbody existence, row count, cell count, label span presence, and Sunday identity — consolidating what was previously split across `validateGraph`, `startWeekOnMonday`, and `getSundayRow`
- `getSundayRow` deleted — redundant now that `validateGraph` confirms row 0 is Sunday before returning true
- `startWeekOnMonday` renamed to `applyCorrection` and simplified to a direct querySelector + validate + realign flow with no internal guard logic
- `tryCorrect` wrapper eliminated — `applyCorrection` is now the single entry point used by the MutationObserver, `turbo:load`, and initial page load
- `getLabelSpan` renamed to `getDayLabel` for clarity