### PR TITLE
Polish manifest metadata, property order, and README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # 📅 Contribution Graph Realignment Tool
+
 A browser extension by The Temporal Correction Initiative, dedicated to restoring chronological integrity to GitHub's contribution graph. Because Monday comes first!
 
 ## 📜 Mission Statement
+
 The Temporal Correction Initiative (TCI) exists to restore harmony between digital representation and temporal reality.
 For too long, developers worldwide have been forced to endured a distorted calender with an unnatural ordering of days, a system that places Sunday, a day of rest, at the forefront of productivity.
 We reject this absurdity, this inversion of logic, and pledge to uphold the universally acknowledged truth: **The week begins on Monday.**
 
 ## 🧭 Founding Principles
+
 1. **Temporal Integrity:** Time shall flow as it was intended: From Monday through Sunday, without distortion.
 2. **Visual Order:** The contribution graph must reflect this truth in both form and function.
 3. **Minimal Disruption:** Correction shall occur silently, elegantly, and without user intervention.
@@ -15,7 +18,8 @@ We reject this absurdity, this inversion of logic, and pledge to uphold the univ
 
 ---
 
-## ❓ Why? Because Sunday is the End, Not the Beginning.
+## ❓ Why? Because Sunday is the End, Not the Beginning
+
 Look, we're all busy coding, but we must adhere to basic temporal logic. The contribution graph is a gorgeous heatmap of productivity, but every time you see that Sunday row sitting stubbornly at the top, a tiny piece of your fastidious soul withers.
 
 This is the standard: Monday is the start of the week. It's the morning the alarm clock screams that the weekend is done and your caffeine reserves must be replenished. Sunday is the final sanctuary, the last moment of peace before the cycle of contribution begins anew.
@@ -25,11 +29,17 @@ This extension is a small act of rebellion against chronological chaos.
 ---
 
 ## 🔧 Features (The Simple Fix)
-### Chronological Correction:
+
+### Chronological Correction
+
 Moves the entire Sunday row to the bottom of the contribution graph.
-### Visual Alignment:
+
+### Visual Alignment
+
 Automatically shifts the contribution squares and reveals the "Sun" label for perfect, Monday-aligned symmetry.
-### Zero Configuration:
+
+### Zero Configuration
+
 Installs silently, works automatically. Just open a GitHub profile and enjoy the peace.
 
 ---

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,6 @@
     "short_name": "C.G.R.T.",
     "version": "0.4.0",
     "description": "A browser extension by The Temporal Correction Initiative. Dedicated to restoring chronological integrity to GitHub's contribution graph. Because Monday comes first!",
-    "author": "The Temporal Correction Initiative",
     "minimum_chrome_version": "88",
     "permissions": [
         "storage"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,14 @@
 {
     "manifest_version": 3,
     "name": "Contribution Graph Realignment Tool",
+    "short_name": "C.G.R.T.",
     "version": "0.4.0",
-    "description": "A browser extension by The GitHub Temporal Correction Initiative. Dedicated to restoring chronological integrity to GitHub's contribution graph. Because Monday comes first!",
+    "description": "A browser extension by The Temporal Correction Initiative. Dedicated to restoring chronological integrity to GitHub's contribution graph. Because Monday comes first!",
+    "author": "The Temporal Correction Initiative",
+    "minimum_chrome_version": "88",
+    "permissions": [
+        "storage"
+    ],
     "content_scripts": [
         {
             "matches": [
@@ -13,19 +19,15 @@
             ]
         }
     ],
+    "options_ui": {
+        "page": "options/options.html",
+        "open_in_tab": true
+    },
     "icons": {
         "16": "icons/icon16.png",
         "32": "icons/icon32.png",
         "48": "icons/icon48.png",
         "128": "icons/icon128.png"
-    },
-    "minimum_chrome_version": "88",
-    "permissions": [
-        "storage"
-    ],
-    "options_ui": {
-        "page": "options/options.html",
-        "open_in_tab": true
     },
     "browser_specific_settings": {
         "gecko": {


### PR DESCRIPTION
## Summary

- Add `short_name` and `author` to `manifest.json`
- Reorder manifest properties into logical groups: identity → constraints → functionality → UI → icons → browser-specific
- Drop "GitHub" from brand name to "The Temporal Correction Initiative"
- Add blank lines after headings and remove trailing punctuation from heading text in `README.md`

## Test plan

- [x] Load unpacked extension in Chrome/Edge and verify it still runs correctly on a GitHub profile page